### PR TITLE
added score support for MAL

### DIFF
--- a/Acerola/data_sources/mal.py
+++ b/Acerola/data_sources/mal.py
@@ -97,7 +97,8 @@ class Mal:
                                                        if isinstance(entry.find('episodes').text, int) else None,
                                         type=get_type(TYPE_MAPPING, entry.find('type').text),
                                         status=get_status(STATUS_MAPPING, entry.find('status').text),
-                                        description=entry.find('synopsis').text))
+                                        description=entry.find('synopsis').text,
+                                        score=float(entry.find('score').text)))
             except AttributeError as e:
                 print(e)
                 # todo - better logging

--- a/Acerola/data_sources/mal.py
+++ b/Acerola/data_sources/mal.py
@@ -131,7 +131,8 @@ class Mal:
                               if isinstance(entry.find('volumes').text, int) else None,
                               type=get_type(TYPE_MAPPING, entry.find('type').text),
                               status=get_status(STATUS_MAPPING, entry.find('status').text),
-                              description=entry.find('synopsis').text)
+                              description=entry.find('synopsis').text,
+                              score=float(entry.find('score').text))
 
                 if manga.type != Type.LIGHT_NOVEL:
                     manga_list.append(manga)
@@ -168,7 +169,8 @@ class Mal:
                                               if isinstance(entry.find('volumes').text, int) else None,
                                 type=get_type(TYPE_MAPPING, entry.find('type').text),
                                 status=get_status(STATUS_MAPPING, entry.find('status').text),
-                                description=entry.find('synopsis').text)
+                                description=entry.find('synopsis').text,
+                                score=float(entry.find('score').text))
 
                 if ln.type == Type.LIGHT_NOVEL:
                     ln_list.append(ln)

--- a/Acerola/response_types.py
+++ b/Acerola/response_types.py
@@ -18,6 +18,7 @@ class Anime:
         self.description = kwargs.get('description')
         self.source = kwargs.get('source')
         self.nsfw = kwargs.get('nsfw')
+        self.score = kwargs.get('score')
 
     def __str__(self):
         return str(self.__dict__)

--- a/Acerola/response_types.py
+++ b/Acerola/response_types.py
@@ -48,7 +48,8 @@ class Anime:
                      type=next((result.type for result in just_the_results if result.type), None),
                      description=next((result.description for result in just_the_results if result.description), None),
                      source=next((result.source for result in just_the_results if result.source), None),
-                     nsfw=next((result.nsfw for result in just_the_results if result.nsfw is not None), None))
+                     nsfw=next((result.nsfw for result in just_the_results if result.nsfw is not None), None),
+                     score=next((result.score for result in just_the_results if result.score is not None), None))
 
 
 class Manga:
@@ -70,6 +71,7 @@ class Manga:
         self.type = kwargs.get('type')
         self.description = kwargs.get('description')
         self.nsfw = kwargs.get('nsfw')
+        self.score = kwargs.get('score')
 
     def __str__(self):
         return str(self.__dict__)
@@ -99,7 +101,8 @@ class Manga:
                      status=next((result.status for result in just_the_results if result.status), None),
                      type=next((result.type for result in just_the_results if result.type), None),
                      description=next((result.description for result in just_the_results if result.description), None),
-                     nsfw=next((result.nsfw for result in just_the_results if result.nsfw is not None), None))
+                     nsfw=next((result.nsfw for result in just_the_results if result.nsfw is not None), None),
+                     score=next((result.score for result in just_the_results if result.score is not None), None))
 
 
 class LightNovel:
@@ -121,6 +124,7 @@ class LightNovel:
         self.type = kwargs.get('type')
         self.description = kwargs.get('description')
         self.nsfw = kwargs.get('nsfw')
+        self.score = kwargs.get('score')
 
     def __str__(self):
         return str(self.__dict__)
@@ -150,4 +154,5 @@ class LightNovel:
                           status=next((result.status for result in just_the_results if result.status), None),
                           type=next((result.type for result in just_the_results if result.type), None),
                           description=next((result.description for result in just_the_results if result.description), None),
-                          nsfw=next((result.nsfw for result in just_the_results if result.nsfw is not None), None))
+                          nsfw=next((result.nsfw for result in just_the_results if result.nsfw is not None), None),
+                          score=next((result.score for result in just_the_results if result.score is not None), None))


### PR DESCRIPTION
I tested this by editing my my `lib/site-packages/Acerola` directory and the proposed changes makes the following possible:

```python
results = acerola.anime.search_closest('Eromanga sensei')
print(type(results[DataSource.MAL].score)) # <class 'float'>
print(results[DataSource.MAL].score) # 7.14
print(type(results[DataSource.ANILIST].score)) # <class 'NoneType'>
print(results[DataSource.ANILIST].score) # None
```